### PR TITLE
Elasticsearch 6.x Extensions

### DIFF
--- a/Cql.Core.Elasticsearch/BulkIndexingDoc.cs
+++ b/Cql.Core.Elasticsearch/BulkIndexingDoc.cs
@@ -1,0 +1,29 @@
+﻿using Newtonsoft.Json.Linq;
+using System.Collections.Generic;
+
+namespace Cql.Core.Elasticsearch
+{
+    /// <summary>
+    /// This represents a command in the bulk indexing payload (https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-bulk.html).
+    /// It will only perform `index` or `delete` commands (no partial `update` command). If the Doc is null, it will delete the ID. Otherwise
+    /// it will perform an `index` command which overwrites the elasticsearch record.
+    /// </summary>
+    public class BulkIndexingDoc
+    {
+        public virtual string ID { get; set; }
+        public virtual JObject Doc { get; set; }
+
+        public IEnumerable<JObject> ToLines()
+        {
+            if (Doc == null)
+            {
+                return new[] { JObject.FromObject(new { delete = new { _id = ID } }) };
+            }
+
+            return new[] {
+                JObject.FromObject(new { index = new { _id = ID } }),
+                Doc
+            };
+        }
+    }
+}

--- a/Cql.Core.Elasticsearch/Cql.Core.Elasticsearch.csproj
+++ b/Cql.Core.Elasticsearch/Cql.Core.Elasticsearch.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <AssemblyName>Cql.Core.Elasticsearch</AssemblyName>
+    <AssemblyTitle>Cql.Core.Elasticsearch</AssemblyTitle>
+    <VersionPrefix>6.8.3</VersionPrefix>
+    <Description>Some helpful extensions to the Elasticsearch low level client. The Version number of this package matches the version number of Elasticsearch.Net</Description>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <TargetFrameworks>net461;netstandard2.0</TargetFrameworks>
+    <Version>6.8.3</Version>
+    <PackageReleaseNotes>https://github.com/cqlcorp/cql.core/wiki/Release-Notes</PackageReleaseNotes>
+    <PackageIconUrl>https://secure.gravatar.com/avatar/7346f295179601173e2a31246657dfcc?s=64</PackageIconUrl>
+    <AssemblyVersion>6.8.3.0</AssemblyVersion>
+    <FileVersion>6.8.3.0</FileVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Elasticsearch.Net" Version="6.8.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
+  </ItemGroup>
+
+</Project>

--- a/Cql.Core.Elasticsearch/ElasticsearchExtensions.cs
+++ b/Cql.Core.Elasticsearch/ElasticsearchExtensions.cs
@@ -1,0 +1,154 @@
+using Elasticsearch.Net;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Cql.Core.Elasticsearch
+{
+    public static class ElasticsearchExtensions
+    {
+        /// <summary>
+        /// This will rebuild an entire index alias behind the scenes with no downtime. It creates a new index
+        /// and populates it then uses Elasticsearch's hot-swapping technique to bring it online.
+        /// </summary>
+        public async static Task RebuildIndexWithHotSwapAsync(
+            this IElasticLowLevelClient client,
+            string alias,
+            JObject indexMapping,
+            Func<Task<IEnumerable<BulkIndexingDoc>>> reader,
+            CancellationToken ctx = default(CancellationToken))
+        {
+            var deletableIndices = JArray.Parse((await client.CatAliasesAsync<StringResponse>(alias, new CatAliasesRequestParameters { Format = "json" }, ctx)).Body)
+                .Select(x => new
+                {
+                    alias = x.Value<string>("alias"),
+                    index = x.Value<string>("index")
+                })
+                .ToList();
+
+            var index = GenerateUniqueIndexNameForAlias(alias);
+
+            await client.IndicesCreateAsync<StringResponse>(index, PostData.String(indexMapping?.ToString()), ctx: ctx);
+
+            while (!ctx.IsCancellationRequested)
+            {
+                // TODO: If an exception is thrown, delete the half-created index
+                var docs = await reader();
+
+                if (ctx.IsCancellationRequested || !docs.Any())
+                {
+                    break;
+                }
+
+                var body = docs.SelectMany(doc => doc.ToLines().Select(x => x.ToString(Formatting.None)));
+                var bulkResponse = await client.BulkAsync<StringResponse>(index, PostData.MultiJson(body));
+
+                ThrowOnPartialBulkSuccess(bulkResponse);
+            }
+
+            if (ctx.IsCancellationRequested)
+            {
+                return;
+            }
+
+            var actions = deletableIndices.Select(idx => (object)new
+            {
+                remove = new { idx.index, idx.alias }
+            }).ToList();
+
+            actions.Add(new { add = new { index, alias } });
+
+            // This is the hot-swap. The actions in the list are performed atomically
+            await client.IndicesUpdateAliasesForAllAsync<StringResponse>(PostData.String(JObject.FromObject(new
+            {
+                actions
+            }).ToString()), ctx: ctx);
+
+            if (deletableIndices.Any())
+            {
+                await client.IndicesDeleteAsync<StringResponse>(string.Join(",", deletableIndices.Select(x => x.index)), ctx: ctx);
+            }
+        }
+
+        /// <summary>
+        /// The Bulk API will return 200 even if individual items fail, so we have to check the status
+        /// of each bulk item.
+        /// This assumes that the elasticsearch client would have already thrown if the overall request failed.
+        /// </summary>
+        public static void ThrowOnPartialBulkSuccess(StringResponse bulkResponse)
+        {
+            if (bulkResponse != null)
+            {
+                var resp = JObject.Parse(bulkResponse.Body);
+
+                if (resp.Value<bool>("errors"))
+                {
+                    // TODO: Improve on this error messaging instead of just dumping out json
+                    throw new ApplicationException("Elasticsearch bulk operation partially failed and was aborted:\n" + resp);
+                }
+            }
+        }
+
+        /// <summary>
+        /// This performs a bulk command against the index pointed at by an alias. This is to avoid the potential for
+        /// a hotswap to change the underlying index from under us while we're reindexing. The index mapping is only
+        /// used if the aliased index does not yet exist.
+        /// </summary>
+        public async static Task BulkTargetingAliasAsync(
+            this IElasticLowLevelClient client,
+            string alias,
+            JObject indexMappingIfNotExists,
+            Func<Task<IEnumerable<BulkIndexingDoc>>> reader,
+            CancellationToken ctx = default(CancellationToken))
+        {
+            var targetIndices = JArray.Parse((await client.CatAliasesAsync<StringResponse>(alias, new CatAliasesRequestParameters { Format = "json" }, ctx)).Body)
+                .Select(x => x.Value<string>("index"))
+                .ToList();
+
+            string index;
+
+            if (targetIndices.Count == 0)
+            {
+                index = GenerateUniqueIndexNameForAlias(alias);
+
+                await client.IndicesCreateAsync<StringResponse>(index, PostData.String(indexMappingIfNotExists?.ToString()), ctx: ctx);
+                await client.IndicesUpdateAliasesForAllAsync<StringResponse>(PostData.String(JObject.FromObject(new
+                {
+                    actions = new[] { new { add = new { index, alias } } }
+                }).ToString()), ctx: ctx);
+            }
+            else if (targetIndices.Count > 1)
+            {
+                throw new ArgumentException(
+                    $"{nameof(BulkTargetingAliasAsync)} can only be used against an alias targeting a single index. The `{alias}` alias covers {targetIndices.Count} indices",
+                    nameof(alias));
+            }
+            else
+            {
+                index = targetIndices.First();
+            }
+
+            while (!ctx.IsCancellationRequested)
+            {
+                var docs = await reader();
+
+                if (ctx.IsCancellationRequested || !docs.Any())
+                {
+                    break;
+                }
+
+                var body = docs.SelectMany(doc => doc.ToLines().Select(x => x.ToString(Formatting.None)));
+                var bulkResponse = await client.BulkAsync<StringResponse>(index, PostData.MultiJson(body));
+
+                ThrowOnPartialBulkSuccess(bulkResponse);
+            }
+        }
+
+        private static string GenerateUniqueIndexNameForAlias(string alias) =>
+             (alias + "-" + DateTimeOffset.UtcNow.ToString("yyyyMMddHHmmssffff")).ToLower();
+    }
+}

--- a/Cql.Core.sln
+++ b/Cql.Core.sln
@@ -51,7 +51,9 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Cql.Core.PetaPoco", "Cql.Co
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Cql.Core.AwsElasticBeanstalk", "Cql.Core.AwsElasticBeanstalk\Cql.Core.AwsElasticBeanstalk.csproj", "{855016DC-CE16-4286-A6A6-AB287D5E23A2}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Cql.Core.AspNetCore.BackgroundTasks", "Cql.Core.AspNetCore.BackgroundTasks\Cql.Core.AspNetCore.BackgroundTasks.csproj", "{D917D907-4008-406B-A106-8714ACEB52CF}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Cql.Core.AspNetCore.BackgroundTasks", "Cql.Core.AspNetCore.BackgroundTasks\Cql.Core.AspNetCore.BackgroundTasks.csproj", "{D917D907-4008-406B-A106-8714ACEB52CF}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Cql.Core.Elasticsearch", "Cql.Core.Elasticsearch\Cql.Core.Elasticsearch.csproj", "{5AAFC697-F5B4-44B7-B3FA-746F6EFE4EB8}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -327,6 +329,18 @@ Global
 		{D917D907-4008-406B-A106-8714ACEB52CF}.Release|x64.Build.0 = Release|Any CPU
 		{D917D907-4008-406B-A106-8714ACEB52CF}.Release|x86.ActiveCfg = Release|Any CPU
 		{D917D907-4008-406B-A106-8714ACEB52CF}.Release|x86.Build.0 = Release|Any CPU
+		{5AAFC697-F5B4-44B7-B3FA-746F6EFE4EB8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5AAFC697-F5B4-44B7-B3FA-746F6EFE4EB8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5AAFC697-F5B4-44B7-B3FA-746F6EFE4EB8}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{5AAFC697-F5B4-44B7-B3FA-746F6EFE4EB8}.Debug|x64.Build.0 = Debug|Any CPU
+		{5AAFC697-F5B4-44B7-B3FA-746F6EFE4EB8}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{5AAFC697-F5B4-44B7-B3FA-746F6EFE4EB8}.Debug|x86.Build.0 = Debug|Any CPU
+		{5AAFC697-F5B4-44B7-B3FA-746F6EFE4EB8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5AAFC697-F5B4-44B7-B3FA-746F6EFE4EB8}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5AAFC697-F5B4-44B7-B3FA-746F6EFE4EB8}.Release|x64.ActiveCfg = Release|Any CPU
+		{5AAFC697-F5B4-44B7-B3FA-746F6EFE4EB8}.Release|x64.Build.0 = Release|Any CPU
+		{5AAFC697-F5B4-44B7-B3FA-746F6EFE4EB8}.Release|x86.ActiveCfg = Release|Any CPU
+		{5AAFC697-F5B4-44B7-B3FA-746F6EFE4EB8}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Directory.build.props
+++ b/Directory.build.props
@@ -1,11 +1,11 @@
 <Project>
   <PropertyGroup>
-    <Copyright>2017 Cql Incorporated</Copyright>  
+    <Copyright>2019 CQL Incorporated</Copyright>
     <PackageId>$(AssemblyName)</PackageId>
     <PackageReleaseNotes>https://github.com/cqlcorp/cql.core</PackageReleaseNotes>
     <PackageProjectUrl>https://github.com/cqlcorp/cql.core</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/cqlcorp/cql.core/License.md</PackageLicenseUrl>
-		<Authors>CQL;Jeremy Bell</Authors>
+		<Authors>CQL;Jeremy Bell;Chad Gilbert</Authors>
 	</PropertyGroup>
 
 	<PropertyGroup>
@@ -35,7 +35,7 @@
 	<PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0'">
 		<DefineConstants>$(DefineConstants);CORE20</DefineConstants>
 	</PropertyGroup>
-  
+
   <ItemGroup>
     <PackageReference Include="NuGet.Build.Tasks.Pack" Version="4.9.1" PrivateAssets="All" />
   </ItemGroup>

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2017 CQL
+Copyright (c) 2019 CQL
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Get the latest versions from Nuget - https://www.nuget.org/packages?q=cql.core
 ## .Net Core and Full Framework Packages
 
 1. **Cql.Core.Common** - A common library for CQL .Net applications.
+1. **Cql.Core.Elasticsearch** - A library containing useful extensions to the Elasticsearch low level client.
 1. **Cql.Core.Web** - Common web features for Owin and AspNetCore web applications.
 1. **Cql.Core.NativeMethods.Logon** - An implementation of the native Windows LogonUser method.
 1. **Cql.Core.Messaging** - Common service implementation for Smtp, Email and SMS messaging.


### PR DESCRIPTION
This adds some helpful extensions to the Elasticsearch low level client. The version number (6.8.3) matches the Elasticsearch.Net version in order to stay in sync between versions. For example, the Elasticsearch.Net v7.x added some breaking changes that are not yet incorporated into this package.